### PR TITLE
Use Docker image alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 as builder
+FROM golang:1.14-alpine as builder
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
To speed up the docker image build time
- improves the build time with 50%

fixes: https://github.com/ribtoks/tdg-github-action/issues/5

please review @ribtoks and merge