### PR TITLE
Don't get authors from API if dry run flag is set

### DIFF
--- a/main.go
+++ b/main.go
@@ -545,7 +545,7 @@ func main() {
 	svc.wg.Add(1)
 	go svc.openNewIssues(issueMap, comments)
 
-	if env.assignFromBlame {
+	if env.assignFromBlame && !env.dryRun {
 		svc.wg.Add(1)
 		go svc.retrieveNewIssueAssignees(issueMap, comments)
 	}
@@ -553,7 +553,7 @@ func main() {
 	log.Printf("Waiting for issues management to finish")
 	svc.wg.Wait()
 
-	if env.assignFromBlame && len(svc.newIssuesMap) > 0 {
+	if env.assignFromBlame && !env.dryRun && len(svc.newIssuesMap) > 0 {
 		svc.assignNewIssues()
 	}
 


### PR DESCRIPTION
@ribtoks Realized that the Git API call was being made even when dry run flag was set. Fixing that in this commit.