### PR TITLE
Log commit author and skip assign issues not created

### DIFF
--- a/main.go
+++ b/main.go
@@ -361,6 +361,7 @@ func (s *service) retrieveCommitAuthor(commitHash string, title string) {
 	} else if commit != nil && commit.Author != nil && len(*commit.Author.Login) > 0 {
 		s.issueTitleToAssigneeMap[title] = *commit.Author.Login
 		s.commitToAuthorCache[commitHash] = *commit.Author.Login
+		log.Printf("Successfully got author '%v' for commit '%v'\nfor issue title '%v'.", *commit.Author.Login, commitHash, title)
 	} else {
 		log.Printf("Error: No author mentioned in commit '%v'", commitHash)
 	}

--- a/main.go
+++ b/main.go
@@ -337,6 +337,10 @@ func (s *service) assignNewIssues() {
 	for title, assignee := range s.issueTitleToAssigneeMap {
 		issue := s.newIssuesMap[title]
 		issueNumber := issue.GetNumber()
+		if issueNumber == 0 {
+			// Issue was not created
+			continue
+		}
 		req := &github.IssueRequest{
 			Assignees: &[]string{assignee},
 		}


### PR DESCRIPTION
- Logging the commit author while retrieving from API
- In some cases (Like ADD_LIMIT being set), some issues might not have been created. In those cases, skip assigning the issue.