### PR TITLE
Add more logging for retrieving author from commit

### DIFF
--- a/main.go
+++ b/main.go
@@ -353,11 +353,9 @@ func (s *service) assignNewIssues() {
 }
 
 func (s *service) retrieveCommitAuthor(commitHash string, title string) {
-	log.Printf("Retrieving author for commit '%v'...", commitHash)
-
 	// First check cache to see if this commit was already retrieved before
 	if commitAuthor, ok := s.commitToAuthorCache[commitHash]; ok {
-		log.Printf("Cache hit. Returning author='%v' for commit '%v'", commitAuthor, commitHash)
+		log.Printf("Found cached author='%v' for commit '%v'", commitAuthor, commitHash)
 		s.issueTitleToAssigneeMap[title] = commitAuthor
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -353,8 +353,11 @@ func (s *service) assignNewIssues() {
 }
 
 func (s *service) retrieveCommitAuthor(commitHash string, title string) {
+	log.Printf("Retrieving author for commit '%v'...", commitHash)
+
 	// First check cache to see if this commit was already retrieved before
 	if commitAuthor, ok := s.commitToAuthorCache[commitHash]; ok {
+		log.Printf("Cache hit. Returning author='%v' for commit '%v'", commitAuthor, commitHash)
 		s.issueTitleToAssigneeMap[title] = commitAuthor
 		return
 	}


### PR DESCRIPTION
On running this action on my repo I noticed that the Commit API was never actually called, and the authors were all just me.

So there's two possible reasons for this:

1. `tdg` doesn't return commithash properly and so [Line 381](https://github.com/ribtoks/tdg-github-action/blob/ec63fe82cf65af299b9848df6c4e2d2478679505/main.go#L381) is never true.
2. `commitToAuthorCache` is misbehaving, and [Line 357](https://github.com/ribtoks/tdg-github-action/blob/ec63fe82cf65af299b9848df6c4e2d2478679505/main.go#L357) is always returning hits. This is more likely the cause as the size of `issueTitleToAssigneeMap` is correct.

Adding more logs to debug this issue.